### PR TITLE
Add specs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Gemfile.lock
+*.gem

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in colonel_kurtz_ruby.gemspec
+gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in colonel_kurtz_ruby.gemspec
+# Specify your gem's dependencies in olive_branch.gemspec
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,9 @@
+require "bundler/gem_tasks"
+
+begin
+  require "rspec/core/rake_task"
+
+  RSpec::Core::RakeTask.new(:spec) 
+  task default: :spec
+rescue LoadError
+end

--- a/Rakefile
+++ b/Rakefile
@@ -2,8 +2,7 @@ require "bundler/gem_tasks"
 
 begin
   require "rspec/core/rake_task"
-
-  RSpec::Core::RakeTask.new(:spec) 
+  RSpec::Core::RakeTask.new(:spec)
   task default: :spec
 rescue LoadError
 end

--- a/lib/olive_branch/middleware.rb
+++ b/lib/olive_branch/middleware.rb
@@ -14,18 +14,20 @@ module OliveBranch
       status, headers, response = @app.call(env)
 
       if inflection && headers["Content-Type"] =~ /application\/json/
-        new_response = JSON.parse(response.body)
+        response.each do |body|
+          new_response = JSON.parse(body)
 
-        if inflection == "camel"
-          new_response.deep_transform_keys! { |k| k.camelize(:lower) }
-        elsif inflection == "dash"
-          new_response.deep_transform_keys!(&:dasherize)
+          if inflection == "camel"
+            new_response.deep_transform_keys! { |k| k.camelize(:lower) }
+          elsif inflection == "dash"
+            new_response.deep_transform_keys!(&:dasherize)
+          end
+
+          body.replace(new_response.to_json)
         end
-
-        [status, headers, [new_response.to_json]]
-      else
-        [status, headers, response]
       end
+
+      [status, headers, response]
     end
   end
 end

--- a/lib/olive_branch/middleware.rb
+++ b/lib/olive_branch/middleware.rb
@@ -15,15 +15,18 @@ module OliveBranch
 
       if inflection && headers["Content-Type"] =~ /application\/json/
         response.each do |body|
-          new_response = JSON.parse(body)
+          begin
+            new_response = JSON.parse(body)
 
-          if inflection == "camel"
-            new_response.deep_transform_keys! { |k| k.camelize(:lower) }
-          elsif inflection == "dash"
-            new_response.deep_transform_keys!(&:dasherize)
+            if inflection == "camel"
+              new_response.deep_transform_keys! { |k| k.camelize(:lower) }
+            elsif inflection == "dash"
+              new_response.deep_transform_keys!(&:dasherize)
+            end
+
+            body.replace(new_response.to_json)
+          rescue JSON::ParserError
           end
-
-          body.replace(new_response.to_json)
         end
       end
 

--- a/olive_branch.gemspec
+++ b/olive_branch.gemspec
@@ -14,4 +14,6 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
 
   s.add_dependency "rails", ">= 4.0"
+
+  s.add_development_dependency "rspec", "~> 3.2"
 end

--- a/spec/olive_branch/middleware_spec.rb
+++ b/spec/olive_branch/middleware_spec.rb
@@ -1,0 +1,132 @@
+require "spec_helper"
+
+RSpec.describe OliveBranch::Middleware do
+  describe "modifying request" do
+    let(:params) do
+      {
+        "action_dispatch.request.request_parameters" => {
+          "post" => {
+            "authorName" => "Adam Smith"
+          }
+        }
+      }
+    end
+
+    it "snake cases incoming params if content-type JSON and inflection header present" do
+      incoming_params = nil
+
+      app = -> (env) do
+        incoming_params = env["action_dispatch.request.request_parameters"]
+        [200, {}, ["{}"]]
+      end
+
+      env = params.merge(
+        "CONTENT_TYPE"        => "application/json",
+        "HTTP_KEY_INFLECTION" => "camel"
+      )
+
+      described_class.new(app).call(env)
+
+      expect(incoming_params["post"]["author_name"]).not_to be_nil
+    end
+
+    it "does not modify incoming params if content-type not JSON" do
+      incoming_params = nil
+
+      app = -> (env) do
+        incoming_params = env["action_dispatch.request.request_parameters"]
+        [200, {}, ["{}"]]
+      end
+
+      env = params.merge(
+        "CONTENT_TYPE"        => "text/html",
+        "HTTP_KEY_INFLECTION" => "camel"
+      )
+
+      described_class.new(app).call(env)
+
+      expect(incoming_params["post"]["authorName"]).not_to be_nil
+    end
+
+    it "does not modify incoming params if inflection header missing" do
+      incoming_params = nil
+
+      app = -> (env) do
+        incoming_params = env["action_dispatch.request.request_parameters"]
+        [200, {}, ["{}"]]
+      end
+
+      env = params.merge("CONTENT_TYPE" => "application/json")
+
+      described_class.new(app).call(env)
+
+      expect(incoming_params["post"]["authorName"]).not_to be_nil
+    end
+  end
+
+  describe "modifying response" do
+    it "camel-cases response if JSON and inflection header present" do
+      app = -> (env) do
+        [
+          200,
+          { "Content-Type" => "application/json" },
+          ['{"post":{"author_name":"Adam Smith"}}']
+        ]
+      end
+
+      request = Rack::MockRequest.new(described_class.new(app))
+
+      response = request.get("/", "HTTP_KEY_INFLECTION" => "camel")
+
+      expect(JSON.parse(response.body)["post"]["authorName"]).not_to be_nil
+    end
+
+    it "dash-cases response if JSON and inflection header present" do
+      app = -> (env) do
+        [
+          200,
+          { "Content-Type" => "application/json" },
+          ['{"post":{"author_name":"Adam Smith"}}']
+        ]
+      end
+
+      request = Rack::MockRequest.new(described_class.new(app))
+
+      response = request.get("/", "HTTP_KEY_INFLECTION" => "dash")
+
+      expect(JSON.parse(response.body)["post"]["author-name"]).not_to be_nil
+    end
+
+    it "does not modify response if not JSON " do
+      app = -> (env) do
+        [
+          200,
+          { "Content-Type" => "text/html" },
+          ['{"post":{"author_name":"Adam Smith"}}']
+        ]
+      end
+
+      request = Rack::MockRequest.new(described_class.new(app))
+
+      response = request.get("/", "HTTP_KEY_INFLECTION" => "camel")
+
+      expect(JSON.parse(response.body)["post"]["author_name"]).not_to be_nil
+    end
+
+    it "does not modify response if inflection header missing" do
+      app = -> (env) do
+        [
+          200,
+          { "Content-Type" => "application/json" },
+          ['{"post":{"author_name":"Adam Smith"}}']
+        ]
+      end
+
+      request = Rack::MockRequest.new(described_class.new(app))
+
+      response = request.get("/")
+
+      expect(JSON.parse(response.body)["post"]["author_name"]).not_to be_nil
+    end
+  end
+end

--- a/spec/olive_branch/middleware_spec.rb
+++ b/spec/olive_branch/middleware_spec.rb
@@ -128,5 +128,21 @@ RSpec.describe OliveBranch::Middleware do
 
       expect(JSON.parse(response.body)["post"]["author_name"]).not_to be_nil
     end
+
+    it "does not modify response if invalid JSON" do
+      app = -> (env) do
+        [
+          200,
+          { "Content-Type" => "application/json" },
+          ['{"post":{"author_name":"Adam Smith"}']
+        ]
+      end
+
+      request = Rack::MockRequest.new(described_class.new(app))
+
+      response = request.get("/", "HTTP_KEY_INFLECTION" => "camel")
+
+      expect(response.body =~ /author_name/).not_to be_nil
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,6 @@
+require "json"
+require "active_support/core_ext/hash/keys"
+require "active_support/inflector"
+require "rack/test"
+
+require "olive_branch"


### PR DESCRIPTION
Modify middleware so that it uses response's `.each` instead of `.body`, as per Rack specification.