### PR TITLE
Respect X-Key-Inflection instead of Key-Inflection header

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This gem lets your API users pass in and receive camelCased or dash-cased keys, 
 
 ## Use
 
-Include a `Key-Inflection` header with values of `camel`, `dash`, or `snake` in your JSON API requests.
+Include a `X-Key-Inflection` header with values of `camel`, `dash`, or `snake` in your JSON API requests.
 
 
 * * *

--- a/lib/olive_branch/middleware.rb
+++ b/lib/olive_branch/middleware.rb
@@ -5,7 +5,7 @@ module OliveBranch
     end
 
     def call(env)
-      inflection = env["HTTP_KEY_INFLECTION"]
+      inflection = env["HTTP_X_KEY_INFLECTION"]
 
       if inflection && env["CONTENT_TYPE"] =~ /application\/json/
         env["action_dispatch.request.request_parameters"].deep_transform_keys!(&:underscore)

--- a/spec/olive_branch/middleware_spec.rb
+++ b/spec/olive_branch/middleware_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe OliveBranch::Middleware do
 
       env = params.merge(
         "CONTENT_TYPE"        => "application/json",
-        "HTTP_KEY_INFLECTION" => "camel"
+        "HTTP_X_KEY_INFLECTION" => "camel"
       )
 
       described_class.new(app).call(env)
@@ -40,7 +40,7 @@ RSpec.describe OliveBranch::Middleware do
 
       env = params.merge(
         "CONTENT_TYPE"        => "text/html",
-        "HTTP_KEY_INFLECTION" => "camel"
+        "HTTP_X_KEY_INFLECTION" => "camel"
       )
 
       described_class.new(app).call(env)
@@ -76,7 +76,7 @@ RSpec.describe OliveBranch::Middleware do
 
       request = Rack::MockRequest.new(described_class.new(app))
 
-      response = request.get("/", "HTTP_KEY_INFLECTION" => "camel")
+      response = request.get("/", "HTTP_X_KEY_INFLECTION" => "camel")
 
       expect(JSON.parse(response.body)["post"]["authorName"]).not_to be_nil
     end
@@ -92,7 +92,7 @@ RSpec.describe OliveBranch::Middleware do
 
       request = Rack::MockRequest.new(described_class.new(app))
 
-      response = request.get("/", "HTTP_KEY_INFLECTION" => "dash")
+      response = request.get("/", "HTTP_X_KEY_INFLECTION" => "dash")
 
       expect(JSON.parse(response.body)["post"]["author-name"]).not_to be_nil
     end
@@ -108,7 +108,7 @@ RSpec.describe OliveBranch::Middleware do
 
       request = Rack::MockRequest.new(described_class.new(app))
 
-      response = request.get("/", "HTTP_KEY_INFLECTION" => "camel")
+      response = request.get("/", "HTTP_X_KEY_INFLECTION" => "camel")
 
       expect(JSON.parse(response.body)["post"]["author_name"]).not_to be_nil
     end
@@ -140,7 +140,7 @@ RSpec.describe OliveBranch::Middleware do
 
       request = Rack::MockRequest.new(described_class.new(app))
 
-      response = request.get("/", "HTTP_KEY_INFLECTION" => "camel")
+      response = request.get("/", "HTTP_X_KEY_INFLECTION" => "camel")
 
       expect(response.body =~ /author_name/).not_to be_nil
     end


### PR DESCRIPTION
According to MDN:

> Custom proprietary headers can be added using the 'X-' prefix

We shouldn't be advising the use of a `Key-Inflection` header, but instead `X-Key-Inflection`