### PR TITLE
Handle Root JSON Array responses

### DIFF
--- a/lib/olive_branch/middleware.rb
+++ b/lib/olive_branch/middleware.rb
@@ -21,9 +21,17 @@ module OliveBranch
             end
 
             if inflection == "camel"
-              new_response.deep_transform_keys! { |k| k.camelize(:lower) }
+              if new_response.is_a? Array
+                new_response.each { |o| o.deep_transform_keys! { |k| k.camelize(:lower)} }
+              else
+                new_response.deep_transform_keys! { |k| k.camelize(:lower) }
+              end
             elsif inflection == "dash"
-              new_response.deep_transform_keys!(&:dasherize)
+              if new_response.is_a? Array
+                new_response.each { |o| o.deep_transform_keys!(&:dasherize) }
+              else
+                new_response.deep_transform_keys!(&:dasherize)
+              end
             end
 
             body.replace(new_response.to_json)

--- a/spec/olive_branch/middleware_spec.rb
+++ b/spec/olive_branch/middleware_spec.rb
@@ -81,6 +81,22 @@ RSpec.describe OliveBranch::Middleware do
       expect(JSON.parse(response.body)["post"]["authorName"]).not_to be_nil
     end
 
+    it 'camel-cases array response if JSON and inflection header present' do
+      app = lambda do |_env|
+        [
+          200,
+          { 'Content-Type' => 'application/json' },
+          ['[{"author_name":"Adam Smith"}]']
+        ]
+      end
+
+      request = Rack::MockRequest.new(described_class.new(app))
+
+      response = request.get('/', 'HTTP_X_KEY_INFLECTION' => 'camel')
+
+      expect(JSON.parse(response.body)[0]['authorName']).not_to be_nil
+    end
+
     it "dash-cases response if JSON and inflection header present" do
       app = -> (env) do
         [
@@ -95,6 +111,22 @@ RSpec.describe OliveBranch::Middleware do
       response = request.get("/", "HTTP_X_KEY_INFLECTION" => "dash")
 
       expect(JSON.parse(response.body)["post"]["author-name"]).not_to be_nil
+    end
+
+    it 'dash-cases array response if JSON and inflection header present' do
+      app = lambda do |_env|
+        [
+          200,
+          { 'Content-Type' => 'application/json' },
+          ['[{"author_name":"Adam Smith"}]']
+        ]
+      end
+
+      request = Rack::MockRequest.new(described_class.new(app))
+
+      response = request.get('/', 'HTTP_X_KEY_INFLECTION' => 'dash')
+
+      expect(JSON.parse(response.body)[0]['author-name']).not_to be_nil
     end
 
     it "does not modify response if not JSON " do


### PR DESCRIPTION
Whenever a JSON Array response is returned the middleware would throw `NoMethodError` exception:

    NoMethodError (undefined method `deep_transform_keys!' for #<Array:0x007fcb9d85c120>):
    olive_branch (1.2.0) lib/olive_branch/middleware.rb:24:in `block (2 levels) in call'

To fix this, we each over the array and perform the `deep_transform_keys!` on each item in the array.