### PR TITLE
Support dash to camel inflection

### DIFF
--- a/lib/olive_branch/middleware.rb
+++ b/lib/olive_branch/middleware.rb
@@ -22,9 +22,9 @@ module OliveBranch
 
           if inflection == "camel"
             if new_response.is_a? Array
-              new_response.each { |o| o.deep_transform_keys! { |k| k.camelize(:lower)} }
+              new_response.each { |o| o.deep_transform_keys! { |k| k.underscore.camelize(:lower)} }
             else
-              new_response.deep_transform_keys! { |k| k.camelize(:lower) }
+              new_response.deep_transform_keys! { |k| k.underscore.camelize(:lower) }
             end
           elsif inflection == "dash"
             if new_response.is_a? Array

--- a/spec/olive_branch/middleware_spec.rb
+++ b/spec/olive_branch/middleware_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe OliveBranch::Middleware do
         [
           200,
           { "Content-Type" => "application/json" },
-          ['{"post":{"author_name":"Adam Smith"}}']
+          ['{"post":{"author_name":"Adam Smith","author-hobby":"Economics"}}']
         ]
       end
 
@@ -79,6 +79,7 @@ RSpec.describe OliveBranch::Middleware do
       response = request.get("/", "HTTP_X_KEY_INFLECTION" => "camel")
 
       expect(JSON.parse(response.body)["post"]["authorName"]).not_to be_nil
+      expect(JSON.parse(response.body)["post"]["authorHobby"]).not_to be_nil
     end
 
     it 'camel-cases array response if JSON and inflection header present' do
@@ -86,7 +87,7 @@ RSpec.describe OliveBranch::Middleware do
         [
           200,
           { 'Content-Type' => 'application/json' },
-          ['[{"author_name":"Adam Smith"}]']
+          ['[{"author_name":"Adam Smith","author-hobby":"Economics"}]']
         ]
       end
 
@@ -95,6 +96,7 @@ RSpec.describe OliveBranch::Middleware do
       response = request.get('/', 'HTTP_X_KEY_INFLECTION' => 'camel')
 
       expect(JSON.parse(response.body)[0]['authorName']).not_to be_nil
+      expect(JSON.parse(response.body)[0]['authorHobby']).not_to be_nil
     end
 
     it "dash-cases response if JSON and inflection header present" do


### PR DESCRIPTION
Context
--

[JSON API](http://jsonapi.org) recommends the use of dashes, which isn't ideal for JS folks. This has [been discussed](https://github.com/json-api/json-api/issues/323) but not addressed.

Solution
--

When camel key inflection is requested, convert dashed keys to camelcase. 