### PR TITLE
Update middleware.rb

### DIFF
--- a/lib/olive_branch/middleware.rb
+++ b/lib/olive_branch/middleware.rb
@@ -36,11 +36,8 @@ module OliveBranch
 
       def underscore_params(env)
         req = ActionDispatch::Request.new(env)
-        req.request_parameters
-        req.query_parameters
-
-        env["action_dispatch.request.request_parameters"].deep_transform_keys!(&:underscore)
-        env["action_dispatch.request.query_parameters"].deep_transform_keys!(&:underscore)
+        req.request_parameters.deep_transform_keys!(&:underscore)
+        req.query_parameters.deep_transform_keys!(&:underscore)
       end
     end
   end


### PR DESCRIPTION
env["action_dispatch.request.request_parameters"] doesnt exist in newer rails versions.
Updating this so that request params can be transformed